### PR TITLE
refactor: Phase 2 - Swift UI component extraction and code simplification

### DIFF
--- a/apps/mac/FamiliarApp/Sources/FamiliarApp/Models/UsageTotals.swift
+++ b/apps/mac/FamiliarApp/Sources/FamiliarApp/Models/UsageTotals.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Token usage and cost tracking for Claude API requests
+struct UsageTotals: Equatable {
+    var inputTokens: Int = 0
+    var outputTokens: Int = 0
+    var cost: Double = 0
+    var currency: String = "USD"
+
+    var totalTokens: Int { inputTokens + outputTokens }
+
+    var hasData: Bool {
+        totalTokens > 0 || cost > 0
+    }
+
+    func adding(_ other: UsageTotals) -> UsageTotals {
+        UsageTotals(
+            inputTokens: inputTokens + other.inputTokens,
+            outputTokens: outputTokens + other.outputTokens,
+            cost: cost + other.cost,
+            currency: currency
+        )
+    }
+
+    init() {}
+
+    init(inputTokens: Int, outputTokens: Int, cost: Double, currency: String) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+        self.cost = cost
+        self.currency = currency
+    }
+}
+
+// MARK: - Parsing from API responses
+
+extension UsageTotals {
+    /// Initialize from API response dictionaries
+    ///
+    /// - Parameters:
+    ///   - usageDict: Dictionary containing inputTokens and outputTokens
+    ///   - costDict: Dictionary containing total cost and currency
+    /// - Returns: UsageTotals instance, or nil if no meaningful data
+    init?(usageDict: [String: Any]?, costDict: [String: Any]?) {
+        guard let usageDict else { return nil }
+        let input = Self.parseInt(usageDict["inputTokens"]) ?? 0
+        let output = Self.parseInt(usageDict["outputTokens"]) ?? 0
+        if input == 0, output == 0, costDict == nil {
+            return nil
+        }
+        let totalCost = Self.parseDouble(costDict?["total"]) ?? 0
+        let currencyValue = (costDict?["currency"] as? String) ?? "USD"
+        inputTokens = input
+        outputTokens = output
+        cost = totalCost
+        currency = currencyValue
+    }
+
+    private static func parseInt(_ value: Any?) -> Int? {
+        switch value {
+        case let intValue as Int:
+            return intValue
+        case let doubleValue as Double:
+            return Int(doubleValue)
+        case let number as NSNumber:
+            return number.intValue
+        default:
+            return nil
+        }
+    }
+
+    private static func parseDouble(_ value: Any?) -> Double? {
+        switch value {
+        case let doubleValue as Double:
+            return doubleValue
+        case let intValue as Int:
+            return Double(intValue)
+        case let number as NSNumber:
+            return number.doubleValue
+        default:
+            return nil
+        }
+    }
+}

--- a/apps/mac/FamiliarApp/Sources/FamiliarApp/Support/LoadingMessageController.swift
+++ b/apps/mac/FamiliarApp/Sources/FamiliarApp/Support/LoadingMessageController.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Manages rotation of loading messages to provide visual feedback during operations
+final class LoadingMessageController {
+    private let phrases: [String]
+    private var currentMessage: String?
+
+    init(phrases: [String]) {
+        self.phrases = phrases
+    }
+
+    /// Get next loading message, avoiding repetition when possible
+    ///
+    /// - Returns: A randomly selected message different from the current one (if possible)
+    func nextMessage() -> String {
+        guard !phrases.isEmpty else {
+            return "Working on it…"
+        }
+
+        var candidate = phrases.randomElement() ?? "Working on it…"
+
+        // Try to avoid repeating the same message
+        if let current = currentMessage, phrases.count > 1 {
+            var attempts = 0
+            while candidate == current && attempts < 5 {
+                candidate = phrases.randomElement() ?? candidate
+                attempts += 1
+            }
+        }
+
+        currentMessage = candidate
+        return candidate
+    }
+
+    /// Reset the controller state
+    func reset() {
+        currentMessage = nil
+    }
+}

--- a/apps/mac/FamiliarApp/Sources/FamiliarApp/UI/APIKeySection.swift
+++ b/apps/mac/FamiliarApp/Sources/FamiliarApp/UI/APIKeySection.swift
@@ -1,0 +1,81 @@
+import AppKit
+import SwiftUI
+
+/// Authentication section for Anthropic API key entry
+///
+/// Provides secure/visible text field for API key entry with clipboard paste support.
+struct APIKeySection: View {
+    @Binding var apiKey: String
+    @Binding var isVisible: Bool
+    let onPaste: () -> Void
+    let onVisibilityToggle: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Provide an Anthropic API key if you prefer manual authentication.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                keyTextField
+                    .textFieldStyle(.roundedBorder)
+
+                Button(action: onVisibilityToggle) {
+                    Image(systemName: isVisible ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.borderless)
+                .help(isVisible ? "Hide API key" : "Show API key")
+
+                Button(action: onPaste) {
+                    Image(systemName: "doc.on.clipboard")
+                }
+                .buttonStyle(.borderless)
+                .help("Paste from clipboard")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var keyTextField: some View {
+        if isVisible {
+            TextField("Anthropic API Key", text: $apiKey)
+        } else {
+            SecureField("Anthropic API Key", text: $apiKey)
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Empty") {
+    APIKeySection(
+        apiKey: .constant(""),
+        isVisible: .constant(false),
+        onPaste: {},
+        onVisibilityToggle: {}
+    )
+    .padding()
+    .frame(width: 400)
+}
+
+#Preview("With Key (Hidden)") {
+    APIKeySection(
+        apiKey: .constant("sk-ant-api03-..."),
+        isVisible: .constant(false),
+        onPaste: {},
+        onVisibilityToggle: {}
+    )
+    .padding()
+    .frame(width: 400)
+}
+
+#Preview("With Key (Visible)") {
+    APIKeySection(
+        apiKey: .constant("sk-ant-api03-abcdefghijklmnopqrstuvwxyz"),
+        isVisible: .constant(true),
+        onPaste: {},
+        onVisibilityToggle: {}
+    )
+    .padding()
+    .frame(width: 400)
+}
+#endif

--- a/apps/mac/FamiliarApp/Sources/FamiliarApp/UI/ClaudeLoginSection.swift
+++ b/apps/mac/FamiliarApp/Sources/FamiliarApp/UI/ClaudeLoginSection.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Authentication section for Claude.ai login flow
+///
+/// Displays sign in/out controls, refresh button, and current authentication status.
+/// Handles the Claude.ai browser-based authentication workflow.
+struct ClaudeLoginSection: View {
+    @Binding var hasSession: Bool
+    @Binding var account: String?
+    @Binding var isLoading: Bool
+    let onSignIn: () -> Void
+    let onSignOut: () -> Void
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Sign in with your Claude.ai account to use Claude Code without managing API keys.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                if hasSession {
+                    Button("Sign Out", action: onSignOut)
+                        .disabled(isLoading)
+                } else {
+                    Button("Sign In", action: onSignIn)
+                        .disabled(isLoading)
+                }
+
+                Button("Refresh Status", action: onRefresh)
+                    .disabled(isLoading)
+
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            accountStatusText
+        }
+    }
+
+    @ViewBuilder
+    private var accountStatusText: some View {
+        if let account = account, !account.isEmpty {
+            Text("Signed in as \(account).")
+                .font(.subheadline)
+        } else if hasSession {
+            Text("Claude account connected.")
+                .font(.subheadline)
+        } else {
+            Text("Not signed in.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Signed In") {
+    ClaudeLoginSection(
+        hasSession: .constant(true),
+        account: .constant("user@example.com"),
+        isLoading: .constant(false),
+        onSignIn: {},
+        onSignOut: {},
+        onRefresh: {}
+    )
+    .padding()
+    .frame(width: 400)
+}
+
+#Preview("Signed Out") {
+    ClaudeLoginSection(
+        hasSession: .constant(false),
+        account: .constant(nil),
+        isLoading: .constant(false),
+        onSignIn: {},
+        onSignOut: {},
+        onRefresh: {}
+    )
+    .padding()
+    .frame(width: 400)
+}
+
+#Preview("Loading") {
+    ClaudeLoginSection(
+        hasSession: .constant(false),
+        account: .constant(nil),
+        isLoading: .constant(true),
+        onSignIn: {},
+        onSignOut: {},
+        onRefresh: {}
+    )
+    .padding()
+    .frame(width: 400)
+}
+#endif


### PR DESCRIPTION
## Phase 2: Swift UI Code Simplification

This PR implements Phase 2 of our comprehensive code cleanup plan, focusing on Swift UI refactorings to extract reusable components and simplify the view layer. This PR builds on Phase 1 (PR #5).

### Changes

#### 1. Extract Authentication Section Components
- **Created** `ClaudeLoginSection.swift` (97 lines)
  - Handles Claude.ai login/logout UI and status display
  - Explicit bindings for session state, account, and loading status
  - Includes SwiftUI previews for all states (signed in, signed out, loading)
- **Created** `APIKeySection.swift` (80 lines)
  - Secure/visible API key entry with clipboard support
  - Bindings for key value and visibility toggle
  - Includes SwiftUI previews for different states
- **Refactored** `SettingsView.swift` (538 → 491 lines initially, -47 lines)
  - Replace inline auth sections with component usage
  - Add helper methods: `pasteFromClipboard()`, `toggleApiKeyVisibility()`
  - Cleaner, more focused main view

**Impact**:
- Improved separation of concerns
- Enhanced testability (components can be tested independently)
- Better code organization with focused responsibilities

#### 2. Consolidate Status Update Functions
- **Unified** status update logic in `SettingsView.swift`
  - Created `updateStatusMessage()` function to handle all status scenarios
  - Reduced duplication across `updateStatusForClaudeMode()` and `updateStatusForApiMode()`
  - Pattern matching for auth mode + authenticated state
- **Simplified** `applySettings()` to use consolidated function

**Impact**:
- Reduced code duplication
- Centralized status message logic
- Easier to maintain and extend

#### 3. Extract Event Handlers in FamiliarViewModel
- **Refactored** `FamiliarViewModel.swift` (253 → 195 lines, -58 lines, -23%)
  - Extracted dedicated event handler methods:
    - `handleAssistantText()`, `handleToolResult()`
    - `handlePermissionRequest()`, `handlePermissionResolution()`
    - `handleResult()`, `handleError()`
  - Main `handle()` method now delegates to specific handlers
  - Improved code organization with MARK comments

**Impact**:
- Better separation of concerns
- Easier to test individual event types
- Improved code readability

#### 4. Move UsageTotals to Model Layer
- **Created** `UsageTotals.swift` model (83 lines)
  - Move UsageTotals struct from FamiliarViewModel
  - Add parsing extension with improved documentation
  - Isolate token/cost tracking logic

**Impact**:
- Clear separation between model and view logic
- Enhanced reusability across the app
- Improved testability

#### 5. Extract LoadingMessageController
- **Created** `LoadingMessageController.swift` (38 lines)
  - Extract loading message rotation logic
  - Provides clean API: `nextMessage()`, `reset()`
  - Avoids repeating the same message when possible
- **Updated** `FamiliarViewModel.swift` to use controller
  - Simplified loading message management
  - Cleaner code organization

**Impact**:
- Isolated loading message concerns
- Testable message rotation logic
- Reduced complexity in ViewModel

### Testing

✅ All 10 Swift tests pass:
```bash
./test-swift.sh
```

✅ All 6 backend tests pass:
```bash
cd backend && uv run pytest tests/ -v
```

- `PromptTextEditorTests`: 9/9 passing
- `SettingsWindowTests`: 1/1 passing

### Summary

**Total Impact**:
- **SettingsView.swift**: 538 → 491 lines (-47 lines, -9%)
- **FamiliarViewModel.swift**: 253 → 195 lines (-58 lines, -23%)
- **New focused components**: 5 files created (298 LOC total)
- **Net reduction**: ~105 LOC in main views
- **Zero behavioral changes** - purely structural improvements
- **Enhanced testability** - all components can be tested independently
- **Improved maintainability** - clearer separation of concerns

**Files Changed**:
- ✨ Created: `ClaudeLoginSection.swift`, `APIKeySection.swift`, `UsageTotals.swift`, `LoadingMessageController.swift`
- 📝 Modified: `SettingsView.swift`, `FamiliarViewModel.swift`

**Builds on Phase 1**:
- Phase 1 (PR #5): Python backend refactorings (~285 LOC reduction)
- Phase 2 (this PR): Swift UI refactorings (~105 LOC reduction in views)
- **Combined total**: ~390 LOC reduction

### Phase 2 Complete

This completes the planned Swift UI refactorings from `docs/implementation/code-simplification.md`. The codebase is now more modular, testable, and maintainable with zero behavioral changes.

---

Part of the comprehensive code simplification plan documented in `docs/implementation/code-simplification.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extract reusable auth UI components, introduce loading-message controller, move UsageTotals to model, and refactor FamiliarViewModel and SettingsView for cleaner, centralized logic.
> 
> - **UI (Settings)**:
>   - Replace inline auth sections with `ClaudeLoginSection` and `APIKeySection` in `SettingsView.swift`.
>   - Consolidate status handling via `updateStatusMessage(...)`; add helpers `pasteFromClipboard()` and `toggleApiKeyVisibility()`.
> - **UI Components**:
>   - Add `UI/ClaudeLoginSection.swift` for Claude.ai sign-in/out and status display (with previews).
>   - Add `UI/APIKeySection.swift` for API key entry with visibility toggle and paste support (with previews).
> - **ViewModel**:
>   - `FamiliarViewModel.swift`: extract event handlers (`handleAssistantText`, `handleToolResult`, `handlePermissionRequest`, `handlePermissionResolution`, `handleResult`, `handleError`).
>   - Replace inline loading phrase logic with `LoadingMessageController` for rotating messages; reset on stop.
>   - Remove embedded `UsageTotals` definition (now uses model).
> - **Models/Support**:
>   - Add `Models/UsageTotals.swift` with parsing from API dictionaries and aggregation helpers.
>   - Add `Support/LoadingMessageController.swift` to manage non-repeating loading messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f64c84e88055de1ec1043cfdf5a8666ede6ec6f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->